### PR TITLE
Fix zoom out scaling

### DIFF
--- a/src/examples/Tree.tsx
+++ b/src/examples/Tree.tsx
@@ -264,7 +264,7 @@ function Tree(props: TreeProps) {
                 </IconButton>
 
                 <IconButton
-                  onClick={() => zoom.scale({ scaleX: 0.8, scaleY: 0.8 })}
+                  onClick={() => zoom.scale({ scaleX: 1 / 1.2, scaleY: 1 / 1.2 })}
                 >
                   <Tooltip title="Zoom out">
                     <ZoomOutIcon />


### PR DESCRIPTION
Ran across an issue following this where a zoom out and in will not return the scale to 1 but 0.96. Thank you so much for these examples, they've been extremely helpful.